### PR TITLE
Make explicitly clear what type of link to enter

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -7,7 +7,7 @@
   %body
     .landing
       %h1 GitTasks
-      %input{type: 'text', placeholder: 'enter git repo here', id: 'git-repo', onkeydown: "javascript: if(event.keyCode == 13) "}
+      %input{type: 'text', placeholder: 'enter git ssh link here (e.g. git@github.com:user/repo.git)', id: 'git-repo', onkeydown: "javascript: if(event.keyCode == 13) "}
       %input.btn{type: 'button', value: 'go', id: 'go-btn'}
       %p The machine running this site needs to have access to the git repository you are trying to access (i.e. pub-key is copied).
   :javascript


### PR DESCRIPTION
At first I tried to enter in the `https` link of the git repo, but that did not seem to work. If this only works with `ssh` links, it could help users trying it out for the first time to know that.
